### PR TITLE
Add the @fake directive.

### DIFF
--- a/lib/graphql/directive.rb
+++ b/lib/graphql/directive.rb
@@ -105,3 +105,4 @@ end
 require "graphql/directive/include_directive"
 require "graphql/directive/skip_directive"
 require "graphql/directive/deprecated_directive"
+require "graphql/directive/fake_directive"

--- a/lib/graphql/directive/fake_directive.rb
+++ b/lib/graphql/directive/fake_directive.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+GraphQL::Directive::FakeDirective = GraphQL::Schema::Directive::Fake.graphql_definition

--- a/lib/graphql/field.rb
+++ b/lib/graphql/field.rb
@@ -11,6 +11,7 @@ module GraphQL
       :property, :hash_key, :complexity,
       :mutation, :function,
       :edge_class,
+      :fake,
       :relay_node_field,
       :relay_nodes_field,
       :subscription_scope,
@@ -20,7 +21,7 @@ module GraphQL
 
     ensure_defined(
       :name, :deprecation_reason, :description, :description=, :property, :hash_key,
-      :mutation, :arguments, :complexity, :function,
+      :mutation, :arguments, :complexity, :function, :fake,
       :resolve, :resolve=, :lazy_resolve, :lazy_resolve=, :lazy_resolve_proc, :resolve_proc,
       :type, :type=, :name=, :property=, :hash_key=,
       :relay_node_field, :relay_nodes_field, :edges?, :edge_class, :subscription_scope,
@@ -48,6 +49,9 @@ module GraphQL
 
     # @return [String, nil] The client-facing reason why this field is deprecated (if present, the field is deprecated)
     attr_accessor :deprecation_reason
+
+    # @return [String, nil] The Faker.js helper method to generate the @fake directive in the Schema
+    attr_accessor :fake
 
     # @return [Hash<String => GraphQL::Argument>] Map String argument names to their {GraphQL::Argument} implementations
     attr_accessor :arguments

--- a/lib/graphql/language/document_from_schema_definition.rb
+++ b/lib/graphql/language/document_from_schema_definition.rb
@@ -77,6 +77,13 @@ module GraphQL
           )
         end
 
+        if field.fake
+          field_node = field_node.merge_directive(
+            name: GraphQL::Directive::FakeDirective.graphql_name,
+            arguments: [GraphQL::Language::Nodes::Argument.new(name: "helper", value: field.fake)]
+          )
+        end
+
         field_node
       end
 

--- a/lib/graphql/schema.rb
+++ b/lib/graphql/schema.rb
@@ -41,6 +41,7 @@ require "graphql/schema/directive/include"
 require "graphql/schema/directive/skip"
 require "graphql/schema/directive/feature"
 require "graphql/schema/directive/transform"
+require "graphql/schema/directive/fake"
 require "graphql/schema/type_membership"
 
 require "graphql/schema/resolver"
@@ -1486,6 +1487,7 @@ module GraphQL
           "include" => GraphQL::Schema::Directive::Include,
           "skip" => GraphQL::Schema::Directive::Skip,
           "deprecated" => GraphQL::Schema::Directive::Deprecated,
+          "fake" => GraphQL::Schema::Directive::Fake,
         }
       end
 

--- a/lib/graphql/schema/directive/fake.rb
+++ b/lib/graphql/schema/directive/fake.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module GraphQL
+  class Schema
+    class Directive < GraphQL::Schema::Member
+      class Fake < GraphQL::Schema::Directive
+        description "Signals graphql-faker to use a particular helper"
+        locations(GraphQL::Schema::Directive::FIELD_DEFINITION, GraphQL::Schema::Directive::ENUM_VALUE)
+
+        helper_description = "Signals which helper to use from the list of helpers here: https://github.com/marak/Faker.js/"
+
+        argument :helper, String, helper_description, default_value: nil, required: false
+        default_directive true
+      end
+    end
+  end
+end

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -166,6 +166,7 @@ module GraphQL
       # @param type [Class, GraphQL::BaseType, Array] The return type of this field
       # @param owner [Class] The type that this field belongs to
       # @param null [Boolean] `true` if this field may return `null`, `false` if it is never `null`
+      # @param fake [String] The Faker.js helper method to generate the @fake directive in the Schema
       # @param description [String] Field description
       # @param deprecation_reason [String] If present, the field is marked "deprecated" with this message
       # @param method [Symbol] The method to call on the underlying object to resolve this field (defaults to `name`)
@@ -188,7 +189,7 @@ module GraphQL
       # @param trace [Boolean] If true, a {GraphQL::Tracing} tracer will measure this scalar field
       # @param ast_node [Language::Nodes::FieldDefinition, nil] If this schema was parsed from definition, this AST node defined the field
       # @param method_conflict_warning [Boolean] If false, skip the warning if this field's method conflicts with a built-in method
-      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, arguments: EMPTY_HASH, &definition_block)
+      def initialize(type: nil, name: nil, owner: nil, null: nil, field: nil, function: nil, fake: nil, description: nil, deprecation_reason: nil, method: nil, hash_key: nil, resolver_method: nil, resolve: nil, connection: nil, max_page_size: nil, scope: nil, introspection: false, camelize: true, trace: nil, complexity: 1, ast_node: nil, extras: [], extensions: EMPTY_ARRAY, connection_extension: self.class.connection_extension, resolver_class: nil, subscription_scope: nil, relay_node_field: false, relay_nodes_field: false, method_conflict_warning: true, arguments: EMPTY_HASH, &definition_block)
         if name.nil?
           raise ArgumentError, "missing first `name` argument or keyword `name:`"
         end
@@ -207,6 +208,7 @@ module GraphQL
         name_s = -name.to_s
         @underscored_name = -Member::BuildType.underscore(name_s)
         @name = -(camelize ? Member::BuildType.camelize(name_s) : name_s)
+        @fake = fake
         @description = description
         if field.is_a?(GraphQL::Schema::Field)
           raise ArgumentError, "Instead of passing a field as `field:`, use `add_field(field)` to add an already-defined field."
@@ -397,6 +399,10 @@ module GraphQL
         field_defn.name = @name
         if @return_type_expr
           field_defn.type = -> { type }
+        end
+
+        if @fake
+          field_defn.fake = @fake
         end
 
         if @description

--- a/lib/graphql/schema/field.rb
+++ b/lib/graphql/schema/field.rb
@@ -27,6 +27,8 @@ module GraphQL
       # @return [String, nil] If present, the field is marked as deprecated with this documentation
       attr_accessor :deprecation_reason
 
+      attr_accessor :fake
+
       # @return [Symbol] Method or hash key on the underlying object to look up
       attr_reader :method_sym
 

--- a/lib/graphql/schema/printer.rb
+++ b/lib/graphql/schema/printer.rb
@@ -103,6 +103,9 @@ module GraphQL
           else
             "@deprecated(reason: #{reason.value.to_s.inspect})"
           end
+        elsif directive.name == "fake"
+          faker = directive.arguments.find { |arg| arg.name == 'helper' }
+          %Q{@fake(type: #{faker.value})}
         else
           super
         end

--- a/spec/graphql/schema/build_from_definition_spec.rb
+++ b/spec/graphql/schema/build_from_definition_spec.rb
@@ -182,7 +182,7 @@ type Hello {
       SCHEMA
 
       built_schema = GraphQL::Schema.from_definition(schema)
-      assert_equal ['deprecated', 'include', 'skip'], built_schema.directives.keys.sort
+      assert_equal ['deprecated', 'fake', 'include', 'skip'], built_schema.directives.keys.sort
     end
 
     it 'supports overriding built-in directives' do


### PR DESCRIPTION
Enables the addition of the @fake directive which graphql-faker and others can use to generate test APIs.

Usage:

field :first_name, String, "description", null: true, fake: "firstName"

The valid values for  are available at https://github.com/marak/Faker.js/

Original Issue: https://github.com/rmosolgo/graphql-ruby/issues/2740